### PR TITLE
Make sure orderId is used instead of order ID for backward compatability

### DIFF
--- a/examples/connect/createOrder.ts
+++ b/examples/connect/createOrder.ts
@@ -71,7 +71,7 @@ try {
         },
     });
 
-    console.log('Order ID:', order.id);
+    console.log('Order ID:', order.orderId);
     console.log('Redirect:', order.links.redirect);
 } catch (error) {
     if (error instanceof ApiError) {

--- a/src/connect/order/Order.ts
+++ b/src/connect/order/Order.ts
@@ -5,7 +5,6 @@ import { NewAddress } from './Address';
 import { Company } from './Customer';
 
 export type Order = {
-    id: string;
     type: string;
     serviceId: string;
     description: string | null;

--- a/tests/connect/support/fakeOrder.ts
+++ b/tests/connect/support/fakeOrder.ts
@@ -1,7 +1,6 @@
 import { Order } from '../../../src';
 
 export const orderCreateResponse: Order = {
-    id: '019642b8-9d82-78cf-83bd-ed07c40e3bad',
     type: 'sale',
     serviceId: 'SL-####-####',
     description: 'Instore Terminal Order #27',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
-  Make sure orderId is used instead of order ID for backward compatability

## How to test
<!--- Create a list of steps people can take to test the changes -->
- [x] `npm install`
- [x] create an order
- [x] See order.orderId is the same as the ID mentioned in the merchant portal.
