### PR TITLE
Move service ID to order create params

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ npm install paynl-sdk --save
 ## Examples
 Some of the basic examples are listed here, for the full list of examples, please take a look at the examples directory [here](https://github.com/paynl/nodejs-sdk/tree/master/src/examples).
 
-All examples start with importing the `paynl-sdk` and creating a client using the API token and service location ID.
+All examples start with importing the `paynl-sdk` and creating a client using the API token.
 
 ```typescript
 import { createPayNLClient } from 'paynl-sdk';
 
-const payNL = createPayNLClient({ apiToken: '****************************************', serviceId: 'SL-####-####' });
+const payNL = createPayNLClient({ apiToken: '****************************************' });
 ```
 
 ## Orders
@@ -30,10 +30,11 @@ Orders use the new Transaction Gateway Unit API. View the [examples](https://git
 
 ### Creating an order
 
-The most minimal request to create an order includes the amount:
+The most minimal request to create an order includes the service location ID and amount:
 
 ```typescript
 const order = await payNL.Orders.create({
+    serviceId: 'SL-####-####',
     amount: {
         value: 1000, // in cents
         currency: 'EUR',
@@ -45,6 +46,7 @@ For testing purposes you may enable the sandbox mode:
 
 ```typescript
 const order = await payNL.Orders.create({
+    serviceId: 'SL-####-####',
     amount: {
         value: 1000, // in cents
         currency: 'EUR',
@@ -74,6 +76,7 @@ This SDK can also add direct debit transactions. In order to do so, you need to 
 
 ```typescript
 const mandate = await payNL.DirectDebit.createMandate({
+    serviceId: 'SL-####-####',
     amount: { value: 1000, currency: 'EUR' },
     description: 'example description',
     type: 'FLEXIBLE',

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,7 +4,10 @@ All notable (breaking) changes to this project will be documented in this file.
 
 ## From 1.2.0 to 2.0.0
 
-As of version 2.0.0, the SDK can no longer create or update transactions using the old REST API.
+As of version 2.0.0, the `serviceId` option has been removed from `createPayNLClient()` and is required to be passed 
+with `payNL.Orders.create({ serviceId: 'SL-####-####' })` and `payNL.DirectDebit.createMandate({ serviceId: 'SL-####-####' })`.
+
+The SDK can no longer create or update transactions using the old REST API.
 All orders need to be created using the new [order API](https://developer.pay.nl/reference/api_create_order-1).
 The `payNL.Orders.status()` method still supports fetching the status of a transaction.
 

--- a/examples/abortOrder.ts
+++ b/examples/abortOrder.ts
@@ -1,6 +1,6 @@
 import { createPayNLClient } from '../src';
 
-const payNL = createPayNLClient({ apiToken: 'your-api-token', serviceId: 'SL-1234-5678' });
+const payNL = createPayNLClient({ apiToken: 'your-api-token' });
 
 const orderId = '00000000-1111-2222-3333-000000000000';
 

--- a/examples/addPayment.ts
+++ b/examples/addPayment.ts
@@ -1,6 +1,6 @@
 import { createPayNLClient } from '../src';
 
-const payNL = createPayNLClient({ apiToken: 'your-api-token', serviceId: 'SL-1234-5678' });
+const payNL = createPayNLClient({ apiToken: 'your-api-token' });
 
 const orderId = '00000000-1111-2222-3333-000000000000';
 

--- a/examples/cancelOrder.ts
+++ b/examples/cancelOrder.ts
@@ -1,6 +1,6 @@
 import { createPayNLClient } from '../src';
 
-const payNL = createPayNLClient({ apiToken: 'your-api-token', serviceId: 'SL-1234-5678' });
+const payNL = createPayNLClient({ apiToken: 'your-api-token' });
 
 const orderId = '00000000-1111-2222-3333-000000000000';
 

--- a/examples/createOrder.ts
+++ b/examples/createOrder.ts
@@ -1,9 +1,10 @@
 import { createPayNLClient, ApiError } from '../src';
 
-const payNL = createPayNLClient({ apiToken: 'your-api-token', serviceId: 'SL-1234-5678' });
+const payNL = createPayNLClient({ apiToken: 'your-api-token' });
 
 try {
     const order = await payNL.Orders.create({
+        serviceId: 'SL-1234-5678',
         description: 'Order ABC0123456789',
         reference: 'abc1234',
         returnUrl: 'https://127.0.0.1/return',

--- a/examples/directDebit.ts
+++ b/examples/directDebit.ts
@@ -2,11 +2,11 @@ import { createPayNLClient } from '../src';
 
 const payNL = createPayNLClient({
     apiToken: 'your-api-token',
-    serviceId: 'SL-1234-5678',
     ATCode: 'AT-1234-5678',
 });
 
 const mandate = await payNL.DirectDebit.createMandate({
+    serviceId: 'SL-1234-5678',
     amount: { value: 1000, currency: 'EUR' },
     description: 'example description',
     type: 'FLEXIBLE',

--- a/examples/fetchOrder.ts
+++ b/examples/fetchOrder.ts
@@ -1,6 +1,6 @@
 import { createPayNLClient } from '../src';
 
-const payNL = createPayNLClient({ apiToken: 'your-api-token', serviceId: 'SL-1234-5678' });
+const payNL = createPayNLClient({ apiToken: 'your-api-token' });
 
 const orderId = '00000000-1111-2222-3333-000000000000';
 

--- a/examples/getPaymentMethods.ts
+++ b/examples/getPaymentMethods.ts
@@ -2,7 +2,6 @@ import { createPayNLClient } from '../src';
 
 const payNL = createPayNLClient({
     apiToken: 'your-api-token',
-    serviceId: 'SL-1234-5678',
     ATCode: 'AT-1234-5678',
 });
 

--- a/examples/orderStatus.ts
+++ b/examples/orderStatus.ts
@@ -1,6 +1,6 @@
 import { createPayNLClient } from '../src';
 
-const payNL = createPayNLClient({ apiToken: 'your-api-token', serviceId: 'SL-1234-5678' });
+const payNL = createPayNLClient({ apiToken: 'your-api-token' });
 
 const orderId = '00000000-1111-2222-3333-000000000000';
 

--- a/examples/updateOrder.ts
+++ b/examples/updateOrder.ts
@@ -1,6 +1,6 @@
 import { createPayNLClient } from '../src';
 
-const payNL = createPayNLClient({ apiToken: 'your-api-token', serviceId: 'SL-1234-5678' });
+const payNL = createPayNLClient({ apiToken: 'your-api-token' });
 
 const orderId = '00000000-1111-2222-3333-000000000000';
 

--- a/examples/verifyOrder.ts
+++ b/examples/verifyOrder.ts
@@ -1,6 +1,6 @@
 import { createPayNLClient } from '../src';
 
-const payNL = createPayNLClient({ apiToken: 'your-api-token', serviceId: 'SL-1234-5678' });
+const payNL = createPayNLClient({ apiToken: 'your-api-token' });
 
 const orderId = '00000000-1111-2222-3333-000000000000';
 

--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -5,7 +5,6 @@ import { RestApiRequest } from './RestApiRequest';
 
 export type ClientOptions = {
     apiToken: string;
-    serviceId: string;
     ATCode?: string;
 };
 

--- a/src/directdebit/DirectDebitApi.ts
+++ b/src/directdebit/DirectDebitApi.ts
@@ -15,10 +15,7 @@ export class DirectDebitApi {
         const response = await this.apiClient.request(
             new RestApiRequest('v2/directdebits/mandates', {
                 method: 'POST',
-                json: {
-                    serviceId: this.apiClient.getOptions().serviceId,
-                    ...mandate,
-                },
+                json: mandate,
             }),
         );
         return await response.body<Mandate>();

--- a/src/directdebit/Mandate.ts
+++ b/src/directdebit/Mandate.ts
@@ -2,6 +2,7 @@ import { CreateAmount } from '../order/Amount';
 import { Stats } from '../shared';
 
 export type CreateMandate = {
+    serviceId: string;
     description: string;
     type: 'SINGLE' | 'RECURRING' | 'FLEXIBLE';
     amount: CreateAmount;

--- a/src/order/CreateOrderOptions.ts
+++ b/src/order/CreateOrderOptions.ts
@@ -6,6 +6,7 @@ import { ResponseProduct } from './Product';
 import { Stats } from '../shared';
 
 export type OrderCreateOptions = {
+    serviceId: string;
     description?: string;
     reference?: string;
     expire?: Date;

--- a/src/order/OrderApi.ts
+++ b/src/order/OrderApi.ts
@@ -19,13 +19,8 @@ export class OrderApi {
      * @see https://developer.pay.nl/reference/api_create_order-1
      */
     async create(options: OrderCreateOptions): Promise<Order> {
-        const body = {
-            ...options,
-            serviceId: this.apiClient.getOptions().serviceId,
-        };
-
         const response = await this.apiClient.request(
-            new ConnectApiRequest('v1/orders', { method: 'POST', json: body }),
+            new ConnectApiRequest('v1/orders', { method: 'POST', json: options }),
         );
 
         return response.body<Order>();

--- a/tests/RestApiRequest.test.ts
+++ b/tests/RestApiRequest.test.ts
@@ -45,7 +45,6 @@ describe('RestApiRequest', () => {
         await expect(async () =>
             subject.getRequestInit({
                 apiToken: ':api-token:',
-                serviceId: 'SL-1234-5678',
             }),
         ).rejects.toThrow(
             new Error(

--- a/tests/createPayNLClient.test.ts
+++ b/tests/createPayNLClient.test.ts
@@ -4,11 +4,9 @@ describe('createPayNLClient', () => {
     it('should return a client class with the given options', () => {
         const givenOptions: ClientOptions = {
             apiToken: 'your-api-token',
-            serviceId: 'SL-1234-5678',
         };
         const expectedOptions = {
             apiToken: 'your-api-token',
-            serviceId: 'SL-1234-5678',
         };
 
         const result = createPayNLClient(givenOptions);

--- a/tests/directdebit/DirectDebitApi.test.ts
+++ b/tests/directdebit/DirectDebitApi.test.ts
@@ -8,6 +8,7 @@ describe('DirectDebitApi', () => {
         const clientMock = new ApiClientMock();
         const subject = new DirectDebitApi(clientMock.getMock());
         const createMandate = {
+            serviceId: 'SL-1234-5678',
             description: fakeDirectDebitMandate.description,
             type: fakeDirectDebitMandate.type,
             amount: fakeDirectDebitMandate.amount,
@@ -15,12 +16,12 @@ describe('DirectDebitApi', () => {
 
         clientMock.mockResponse(fakeDirectDebitMandate);
 
-        const response = await subject.createMandate(createMandate as CreateMandate);
+        const response = await subject.createMandate(createMandate satisfies CreateMandate);
 
         expect(response).toEqual(fakeDirectDebitMandate);
         expect(clientMock.getRequest()).toEqual({
             url: 'https://rest.pay.nl/v2/directdebits/mandates',
-            options: { method: 'POST', json: { serviceId: 'SL-1234-5678', ...createMandate } },
+            options: { method: 'POST', json: createMandate },
         });
     });
 
@@ -36,7 +37,7 @@ describe('DirectDebitApi', () => {
 
         clientMock.mockResponse(fakeDirectDebit);
 
-        const response = await subject.add(createDirectDebit as CreateDirectDebit);
+        const response = await subject.add(createDirectDebit satisfies CreateDirectDebit);
 
         expect(response).toEqual(fakeDirectDebit);
         expect(clientMock.getRequest()).toEqual({

--- a/tests/order/OrderApi.test.ts
+++ b/tests/order/OrderApi.test.ts
@@ -15,6 +15,7 @@ describe('OrderApi', () => {
         clientMock.mockResponse(orderCreateResponse);
 
         const response = await subject.create({
+            serviceId: 'SL-1234-5678',
             amount: {
                 value: 1000,
                 currency: 'EUR',
@@ -50,10 +51,7 @@ describe('OrderApi', () => {
             url: 'https://connect.pay.nl/v1/orders',
             options: {
                 method: 'POST',
-                json: {
-                    ...fakeCreateOrderOptions,
-                    serviceId: 'SL-1234-5678',
-                },
+                json: fakeCreateOrderOptions,
             },
         });
     });
@@ -76,6 +74,7 @@ describe('OrderApi', () => {
         await expect(
             async () =>
                 await subject.create({
+                    serviceId: 'SL-1234-5678',
                     amount: {
                         value: 1000,
                         currency: 'EUR',

--- a/tests/support/fakeCreateOrderOptions.ts
+++ b/tests/support/fakeCreateOrderOptions.ts
@@ -1,6 +1,7 @@
 import { OrderCreateOptions } from '../../src/order/CreateOrderOptions';
 
 export const fakeCreateOrderOptions: OrderCreateOptions = {
+    serviceId: 'SL-1234-5678',
     description: 'Order ABC0123456789',
     reference: 'abc1234',
     returnUrl: 'https://127.0.0.1/return',

--- a/tests/support/fakeDirectDebit.ts
+++ b/tests/support/fakeDirectDebit.ts
@@ -1,4 +1,6 @@
-export const fakeDirectDebitMandate = {
+import { Mandate } from '../../src';
+
+export const fakeDirectDebitMandate: Mandate = {
     code: 'IO-####-####-####',
     serviceId: 'SL-####-####',
     reference: 'AX12345-TRA-6789',

--- a/tests/support/mockClientOptions.ts
+++ b/tests/support/mockClientOptions.ts
@@ -2,6 +2,5 @@ import { ClientOptions } from '../../src';
 
 export const mockClientOptions: ClientOptions = {
     apiToken: ':api-token:',
-    serviceId: 'SL-1234-5678',
     ATCode: 'AT-1234-5678',
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- this MR
- #13 
- #14 

## Description
<!--- Describe your changes in detail -->
- Moved the serviceID param to `client.Order.create()`
- Moved the serviceID param to `client.DirectDebit.createMandate()`

## How to test
<!--- Create a list of steps people can take to test the changes -->
- [ ] `npm install`
- [ ] run create order in examples
